### PR TITLE
3.7 send payload

### DIFF
--- a/examples/echoclient.rs
+++ b/examples/echoclient.rs
@@ -16,9 +16,7 @@ fn echo_client(remote_addr: Ipv4Addr, remote_port: u16) -> Result<()> {
     loop {
         let mut input = String::new();
         io::stdin().read_line(&mut input)?;
-        loop {
-            tcp.send(sock_id, input.repeat(2000).as_bytes())?;
-        }
+        tcp.send(sock_id, input.as_bytes())?;
     }
     Ok(())
 }

--- a/examples/echoclient.rs
+++ b/examples/echoclient.rs
@@ -12,6 +12,13 @@ fn main() -> Result<()> {
 
 fn echo_client(remote_addr: Ipv4Addr, remote_port: u16) -> Result<()> {
     let tcp = TCP::new();
-    let _ = tcp.connect(remote_addr, remote_port)?;
+    let sock_id = tcp.connect(remote_addr, remote_port)?;
+    loop {
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        loop {
+            tcp.send(sock_id, input.repeat(2000).as_bytes())?;
+        }
+    }
     Ok(())
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -22,6 +22,7 @@ pub struct Socket {
     pub send_param: SendParam,
     pub recv_param: RecvParam,
     pub status: TcpStatus,
+    pub retransmission_queue: VecDeque<RetransmissionQueueEntry>,
     pub connected_connection_queue: VecDeque<SockID>,
     pub listening_socket: Option<SockID>,
     pub sender: TransportSender,
@@ -41,6 +42,13 @@ pub struct RecvParam {
     pub next: u32,
     pub tail: u32,
     pub window: u16,
+}
+
+#[derive(Clone, Debug)]
+pub struct RetransmissionQueueEntry {
+    pub packet: TCPPacket,
+    pub latest_transmission_time: SystemTime,
+    pub transmission_count: u8,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -104,6 +112,7 @@ impl Socket {
                 window: SOCKET_BUFFER_SIZE as u16,
             },
             status,
+            retransmission_queue: VecDeque::new(),
             connected_connection_queue: VecDeque::new(),
             listening_socket: None,
             sender,
@@ -139,8 +148,14 @@ impl Socket {
             .sender
             .send_to(tcp_packet.clone(), IpAddr::V4(self.remote_addr))
             .context(format!("failed to send: \n{:?}", tcp_packet))?;
-
         dbg!("sent", &tcp_packet);
+
+        if payload.is_empty() && tcp_packet.get_flag() == tcpflags::ACK {
+            return Ok(sent_size);
+        }
+        self.retransmission_queue
+            .push_back(RetransmissionQueueEntry::new(tcp_packet));
+
         Ok(sent_size)
     }
 
@@ -151,5 +166,15 @@ impl Socket {
             self.local_port,
             self.remote_port,
         )
+    }
+}
+
+impl RetransmissionQueueEntry {
+    fn new(packet: TCPPacket) -> Self {
+        Self {
+            packet,
+            latest_transmission_time: SystemTime::now(),
+            transmission_count: 1,
+        }
     }
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -14,8 +14,8 @@ use std::{cmp, ops::Range, str, thread};
 
 const UNDETERMINED_IP_ADDR: std::net::Ipv4Addr = Ipv4Addr::new(0, 0, 0, 0);
 const UNDETERMINED_PORT: u16 = 0;
-const MAX_TRANSMITTION: u8 = 5;
-const RETRANSMITTION_TIMEOUT: u64 = 3;
+const MAX_TRANSMISSION: u8 = 5;
+const RETRANSMISSION_TIMEOUT: u64 = 3;
 const MSS: usize = 1460;
 const PORT_RANGE: Range<u16> = 40000..60000;
 
@@ -54,6 +54,10 @@ impl TCP {
         let cloned_tcp = tcp.clone();
         std::thread::spawn(move || {
             cloned_tcp.receive_handler().unwrap();
+        });
+        let cloned_tcp = tcp.clone();
+        std::thread::spawn(move || {
+            cloned_tcp.timer();
         });
         tcp
     }
@@ -149,6 +153,7 @@ impl TCP {
                 TcpStatus::Listen => self.listen_handler(table, sock_id, &packet, remote_addr),
                 TcpStatus::SynSent => self.synsent_handler(socket, &packet),
                 TcpStatus::SynRcvd => self.synrcvd_handler(table, sock_id, &packet),
+                TcpStatus::Established => self.established_handler(socket, &packet),
                 _ => {
                     dbg!("not implemented state");
                     Ok(())
@@ -283,6 +288,77 @@ impl TCP {
         cvar.notify_all();
     }
 
+    fn timer(&self) {
+        dbg!("begin timer thread");
+        loop {
+            let mut table = self.sockets.write().unwrap();
+            for (sock_id, socket) in table.iter_mut() {
+                while let Some(mut item) = socket.retransmission_queue.pop_front() {
+                    if socket.send_param.unacked_seq > item.packet.get_seq() {
+                        dbg!("successfully acked", item.packet.get_seq());
+                        socket.send_param.window += item.packet.payload().len() as u16;
+                        self.publish_event(*sock_id, TCPEventKind::Acked);
+                        continue;
+                    }
+                    if item.latest_transmission_time.elapsed().unwrap()
+                        < Duration::from_secs(RETRANSMISSION_TIMEOUT)
+                    {
+                        socket.retransmission_queue.push_front(item);
+                        break;
+                    }
+                    if item.transmission_count < MAX_TRANSMISSION {
+                        dbg!("retransmit");
+                        socket
+                            .sender
+                            .send_to(item.packet.clone(), IpAddr::V4(socket.remote_addr))
+                            .context("failed to retransmit")
+                            .unwrap();
+                        item.transmission_count += 1;
+                        item.latest_transmission_time = SystemTime::now();
+                        socket.retransmission_queue.push_back(item);
+                        break;
+                    } else {
+                        dbg!("reached MAX_TRANSMISSION");
+                    }
+                }
+            }
+            drop(table);
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    fn delete_acked_segment_from_retransmission_queue(&self, socket: &mut Socket) {
+        dbg!("ack accept", socket.send_param.unacked_seq);
+        // TODO: Research about deque
+        while let Some(item) = socket.retransmission_queue.pop_front() {
+            if socket.send_param.unacked_seq > item.packet.get_seq() {
+                dbg!("successfully acked", item.packet.get_seq());
+                socket.send_param.window += item.packet.payload().len() as u16;
+                self.publish_event(socket.get_sock_id(), TCPEventKind::Acked);
+            } else {
+                socket.retransmission_queue.push_front(item);
+                break;
+            }
+        }
+    }
+
+    fn established_handler(&self, socket: &mut Socket, packet: &TCPPacket) -> Result<()> {
+        dbg!("established handler");
+        if socket.send_param.unacked_seq < packet.get_ack()
+            && packet.get_ack() <= socket.send_param.next
+        {
+            socket.send_param.unacked_seq = packet.get_ack();
+            self.delete_acked_segment_from_retransmission_queue(socket);
+        } else if socket.send_param.next < packet.get_ack() {
+            return Ok(());
+        }
+
+        if packet.get_flag() & tcpflags::ACK == 0 {
+            return Ok(());
+        }
+        Ok(())
+    }
+
     pub fn listen(&self, local_addr: Ipv4Addr, local_port: u16) -> Result<SockID> {
         let socket = Socket::new(
             local_addr,
@@ -306,6 +382,48 @@ impl TCP {
             .connected_connection_queue
             .pop_front()
             .context("no connected socket")?)
+    }
+
+    pub fn send(&self, sock_id: SockID, buffer: &[u8]) -> Result<()> {
+        let mut cursor = 0;
+        while cursor < buffer.len() {
+            let mut table = self.sockets.write().unwrap();
+            let mut socket = table
+                .get_mut(&sock_id)
+                .context(format!("no such socket: {:?}", sock_id))?;
+            let mut send_size = cmp::min(
+                MSS,
+                cmp::min(socket.send_param.window as usize, buffer.len() - cursor),
+            );
+
+            while send_size == 0 {
+                dbg!("unable to slide send window");
+                drop(table);
+                self.wait_event(sock_id, TCPEventKind::Acked);
+                table = self.sockets.write().unwrap();
+                socket = table
+                    .get_mut(&sock_id)
+                    .context(format!("no such socket: {:?}", sock_id))?;
+                send_size = cmp::min(
+                    MSS,
+                    cmp::min(socket.send_param.window as usize, buffer.len() - cursor),
+                );
+            }
+            dbg!("current window size", socket.send_param.window);
+
+            socket.send_tcp_packet(
+                socket.send_param.next,
+                socket.recv_param.next,
+                tcpflags::ACK,
+                &buffer[cursor..cursor + send_size],
+            )?;
+            cursor += send_size;
+            socket.send_param.next += send_size as u32;
+            socket.send_param.window -= send_size as u16;
+            drop(table);
+            thread::sleep(Duration::from_millis(1));
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Overview

「3.7 ペイロードの送信」まで実装

- パケット再送
- slide window

## Test

- Sample output of testing retransmission (client):

```text
hello
[src/tcp.rs:412] "current window size" = "current window size"
[src/tcp.rs:412] socket.send_param.window = 32120
[src/socket.rs:151] "sent" = "sent"
[src/socket.rs:151] &tcp_packet =
            src: 46558
            dst: 40000
            flag: ACK
            payload_len: 6
[src/tcp.rs:310] "retransmit" = "retransmit"
[src/tcp.rs:310] "retransmit" = "retransmit"
[src/tcp.rs:346] "established handler" = "established handler"
[src/tcp.rs:331] "ack accept" = "ack accept"
[src/tcp.rs:331] socket.send_param.unacked_seq = 979974231
[src/tcp.rs:335] "successfully acked" = "successfully acked"
[src/tcp.rs:335] item.packet.get_seq() = 979974225
```

- Sample output of testing slide window (client):

```text
[src/tcp.rs:412] "current window size" = "current window size"
[src/tcp.rs:412] socket.send_param.window = 3000
[src/socket.rs:151] "sent" = "sent"
[src/socket.rs:151] &tcp_packet =
            src: 45604
            dst: 40000
            flag: ACK
            payload_len: 1460
[src/tcp.rs:412] "current window size" = "current window size"
[src/tcp.rs:412] socket.send_param.window = 1540
[src/socket.rs:151] "sent" = "sent"
[src/socket.rs:151] &tcp_packet =
            src: 45604
            dst: 40000
            flag: ACK
            payload_len: 1460
[src/tcp.rs:412] "current window size" = "current window size"
[src/tcp.rs:412] socket.send_param.window = 80
[src/socket.rs:151] "sent" = "sent"
[src/socket.rs:151] &tcp_packet =
            src: 45604
            dst: 40000
            flag: ACK
            payload_len: 80
[src/tcp.rs:400] "unable to slide send window" = "unable to slide send window"
[src/tcp.rs:280] &event = Some(
    TCPEvent {
        sock_id: SockID(
            10.0.0.1,
            10.0.1.1,
            45604,
            40000,
        ),
        kind: Acked,
    },
)
[src/tcp.rs:400] "unable to slide send window" = "unable to slide send window"
[src/tcp.rs:346] "established handler" = "established handler"
[src/tcp.rs:331] "ack accept" = "ack accept"
[src/tcp.rs:331] socket.send_param.unacked_seq = 353170772
[src/tcp.rs:335] "successfully acked" = "successfully acked"
[src/tcp.rs:335] item.packet.get_seq() = 353167852
[src/tcp.rs:335] "successfully acked" = "successfully acked"
[src/tcp.rs:335] item.packet.get_seq() = 353169312
[src/tcp.rs:280] &event = Some(
    TCPEvent {
        sock_id: SockID(
            10.0.0.1,
            10.0.1.1,
            45604,
            40000,
        ),
        kind: Acked,
    },
)
[src/tcp.rs:412] "current window size" = "current window size"
[src/tcp.rs:412] socket.send_param.window = 2920
[src/socket.rs:151] "sent" = "sent"
[src/socket.rs:151] &tcp_packet =
            src: 45604
            dst: 40000
            flag: ACK
            payload_len: 1460
[src/tcp.rs:346] "established handler" = "established handler"
[src/tcp.rs:331] "ack accept" = "ack accept"
[src/tcp.rs:331] socket.send_param.unacked_seq = 353173692
[src/tcp.rs:335] "successfully acked" = "successfully acked"
[src/tcp.rs:335] item.packet.get_seq() = 353170772
[src/tcp.rs:335] "successfully acked" = "successfully acked"
[src/tcp.rs:335] item.packet.get_seq() = 353172232
[src/tcp.rs:412] "current window size" = "current window size"
[src/tcp.rs:412] socket.send_param.window = 4380
```