### PR TITLE
3.9 close

### DIFF
--- a/examples/echoclient.rs
+++ b/examples/echoclient.rs
@@ -13,6 +13,13 @@ fn main() -> Result<()> {
 fn echo_client(remote_addr: Ipv4Addr, remote_port: u16) -> Result<()> {
     let tcp = TCP::new();
     let sock_id = tcp.connect(remote_addr, remote_port)?;
+
+    let cloned_tcp = tcp.clone();
+    ctrlc::set_handler(move || {
+        cloned_tcp.close(sock_id).unwrap();
+        std::process::exit(0);
+    })?;
+
     loop {
         let mut input = String::new();
         io::stdin().read_line(&mut input)?;

--- a/examples/echoserver.rs
+++ b/examples/echoserver.rs
@@ -24,6 +24,8 @@ fn echo_server(local_addr: Ipv4Addr, local_port: u16) -> Result<()> {
             loop {
                 let nbytes = cloned_tcp.recv(connected_socket, &mut buffer).unwrap();
                 if nbytes == 0 {
+                    dbg!("closing connection..");
+                    cloned_tcp.close(connected_socket).unwrap();
                     return;
                 }
                 print!("> {}", str::from_utf8(&buffer[..nbytes]).unwrap());

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -154,6 +154,8 @@ impl TCP {
                 TcpStatus::SynSent => self.synsent_handler(socket, &packet),
                 TcpStatus::SynRcvd => self.synrcvd_handler(table, sock_id, &packet),
                 TcpStatus::Established => self.established_handler(socket, &packet),
+                TcpStatus::CloseWait | TcpStatus::LastAck => self.close_handler(socket, &packet),
+                TcpStatus::FinWait1 | TcpStatus::FinWait2 => self.finwait_handler(socket, &packet),
                 _ => {
                     dbg!("not implemented state");
                     Ok(())
@@ -298,6 +300,12 @@ impl TCP {
                         dbg!("successfully acked", item.packet.get_seq());
                         socket.send_param.window += item.packet.payload().len() as u16;
                         self.publish_event(*sock_id, TCPEventKind::Acked);
+
+                        if item.packet.get_flag() & tcpflags::FIN > 0
+                            && socket.status == TcpStatus::LastAck
+                        {
+                            self.publish_event(*sock_id, TCPEventKind::ConnectionClosed);
+                        }
                         continue;
                     }
                     if item.latest_transmission_time.elapsed().unwrap()
@@ -319,6 +327,13 @@ impl TCP {
                         break;
                     } else {
                         dbg!("reached MAX_TRANSMISSION");
+                        if item.packet.get_flag() & tcpflags::FIN > 0
+                            && (socket.status == TcpStatus::LastAck
+                                || socket.status == TcpStatus::FinWait1
+                                || socket.status == TcpStatus::FinWait2)
+                        {
+                            self.publish_event(*sock_id, TCPEventKind::ConnectionClosed);
+                        }
                     }
                 }
             }
@@ -387,6 +402,60 @@ impl TCP {
         if !packet.payload().is_empty() {
             self.process_payload(socket, &packet)?;
         }
+
+        if packet.get_flag() & tcpflags::FIN > 0 {
+            socket.recv_param.next = packet.get_seq() + 1;
+            socket.send_tcp_packet(
+                socket.send_param.next,
+                socket.recv_param.next,
+                tcpflags::ACK,
+                &[],
+            )?;
+            socket.status = TcpStatus::CloseWait;
+            self.publish_event(socket.get_sock_id(), TCPEventKind::DataArrived);
+        }
+        Ok(())
+    }
+
+    fn finwait_handler(&self, socket: &mut Socket, packet: &TCPPacket) -> Result<()> {
+        dbg!("finwait handler");
+        if socket.send_param.unacked_seq < packet.get_ack()
+            && packet.get_ack() <= socket.send_param.next
+        {
+            socket.send_param.unacked_seq = packet.get_ack();
+            self.delete_acked_segment_from_retransmission_queue(socket);
+        } else if socket.send_param.next < packet.get_ack() {
+            return Ok(());
+        }
+        if packet.get_flag() & tcpflags::ACK == 0 {
+            return Ok(());
+        }
+        if !packet.payload().is_empty() {
+            self.process_payload(socket, &packet)?;
+        }
+        if socket.status == TcpStatus::FinWait1
+            && socket.send_param.next == socket.send_param.unacked_seq
+        {
+            socket.status = TcpStatus::FinWait2;
+            dbg!("status: finwait1 ->", &socket.status);
+        }
+
+        if packet.get_flag() & tcpflags::FIN > 0 {
+            socket.recv_param.next += 1;
+            socket.send_tcp_packet(
+                socket.send_param.next,
+                socket.recv_param.next,
+                tcpflags::ACK,
+                &[],
+            )?;
+            self.publish_event(socket.get_sock_id(), TCPEventKind::ConnectionClosed);
+        }
+        Ok(())
+    }
+
+    fn close_handler(&self, socket: &mut Socket, packet: &TCPPacket) -> Result<()> {
+        dbg!("closewait | lastack handler");
+        socket.send_param.unacked_seq = packet.get_ack();
         Ok(())
     }
 
@@ -465,6 +534,10 @@ impl TCP {
         let mut received_size = socket.recv_buffer.len() - socket.recv_param.window as usize;
 
         while received_size == 0 {
+            match socket.status {
+                TcpStatus::CloseWait | TcpStatus::LastAck | TcpStatus::TimeWait => break,
+                _ => {}
+            }
             drop(table);
             dbg!("waiting incoming data");
             self.wait_event(sock_id, TCPEventKind::DataArrived);
@@ -480,6 +553,43 @@ impl TCP {
         socket.recv_buffer.copy_within(copy_size.., 0);
         socket.recv_param.window += copy_size as u16;
         Ok(copy_size)
+    }
+
+    pub fn close(&self, sock_id: SockID) -> Result<()> {
+        let mut table = self.sockets.write().unwrap();
+        let mut socket = table
+            .get_mut(&sock_id)
+            .context(format!("no such socket: {:?}", sock_id))?;
+        socket.send_tcp_packet(
+            socket.send_param.next,
+            socket.recv_param.next,
+            tcpflags::FIN | tcpflags::ACK,
+            &[],
+        )?;
+        socket.send_param.next += 1;
+        match socket.status {
+            TcpStatus::Established => {
+                socket.status = TcpStatus::FinWait1;
+                drop(table);
+                self.wait_event(sock_id, TCPEventKind::ConnectionClosed);
+                let mut table = self.sockets.write().unwrap();
+                table.remove(&sock_id);
+                dbg!("closed & removed", sock_id);
+            }
+            TcpStatus::CloseWait => {
+                socket.status = TcpStatus::LastAck;
+                drop(table);
+                self.wait_event(sock_id, TCPEventKind::ConnectionClosed);
+                let mut table = self.sockets.write().unwrap();
+                table.remove(&sock_id);
+                dbg!("closed & removed", sock_id);
+            }
+            TcpStatus::Listen => {
+                table.remove(&sock_id);
+            }
+            _ => return Ok(()),
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Overview

「3.9 コネクションの切断」まで実装

## Test

- server:

```text
% sudo ip netns exec host2 ./target/debug/examples/echoserver 10.0.1.1 40000
[src/tcp.rs:101] "begin recv thread" = "begin recv thread"
[src/tcp.rs:294] "begin timer thread" = "begin timer thread"
[examples/echoserver.rs:16] "listening.." = "listening.."
[src/tcp.rs:176] "listen handler" = "listen handler"
[src/socket.rs:153] "sent" = "sent"
[src/socket.rs:153] &tcp_packet =
            src: 40000
            dst: 47797
            flag: SYN ACK
            payload_len: 0
[src/tcp.rs:203] "status: listen -> " = "status: listen -> "
[src/tcp.rs:203] &connection_socket.status = SynRcvd
[src/tcp.rs:251] "SynRcvd handler" = "SynRcvd handler"
[src/tcp.rs:261] "status: synrcvd ->" = "status: synrcvd ->"
[src/tcp.rs:261] &socket.status = Established
[src/tcp.rs:282] &event = Some(
    TCPEvent {
        sock_id: SockID(
            10.0.1.1,
            0.0.0.0,
            40000,
            0,
        ),
        kind: ConnectionCompleted,
    },
)
[examples/echoserver.rs:19] "accepted!" = "accepted!"
[examples/echoserver.rs:19] connected_socket.1 = 10.0.0.1
[examples/echoserver.rs:19] connected_socket.3 = 47797
[src/tcp.rs:542] "waiting incoming data" = "waiting incoming data"
[src/tcp.rs:300] "successfully acked" = "successfully acked"
[src/tcp.rs:300] item.packet.get_seq() = 613189214
[src/tcp.rs:388] "established handler" = "established handler"
[src/socket.rs:153] "sent" = "sent"
[src/socket.rs:153] &tcp_packet =
            src: 40000
            dst: 47797
            flag: ACK
            payload_len: 0
[src/tcp.rs:282] &event = Some(
    TCPEvent {
        sock_id: SockID(
            10.0.1.1,
            10.0.0.1,
            40000,
            47797,
        ),
        kind: DataArrived,
    },
)
[examples/echoserver.rs:27] "closing connection.." = "closing connection.."
[src/socket.rs:153] "sent" = "sent"
[src/socket.rs:153] &tcp_packet =
            src: 40000
            dst: 47797
            flag: ACK FIN
            payload_len: 0
[src/tcp.rs:457] "closewait | lastack handler" = "closewait | lastack handler"
[src/tcp.rs:300] "successfully acked" = "successfully acked"
[src/tcp.rs:300] item.packet.get_seq() = 613189215
[src/tcp.rs:282] &event = Some(
    TCPEvent {
        sock_id: SockID(
            10.0.1.1,
            10.0.0.1,
            40000,
            47797,
        ),
        kind: ConnectionClosed,
    },
)
[src/tcp.rs:585] "closed & removed" = "closed & removed"
[src/tcp.rs:585] sock_id = SockID(
    10.0.1.1,
    10.0.0.1,
    40000,
    47797,
)
```

- client:

```text
% sudo ip netns exec host1 ./target/debug/examples/echoclient 10.0.1.1 40000
[src/tcp.rs:101] "begin recv thread" = "begin recv thread"
[src/tcp.rs:294] "begin timer thread" = "begin timer thread"
[src/tcp.rs:610] "source addr" = "source addr"
[src/tcp.rs:610] ip = "10.0.0.1"
[src/socket.rs:153] "sent" = "sent"
[src/socket.rs:153] &tcp_packet =
            src: 47797
            dst: 40000
            flag: SYN
            payload_len: 0
[src/tcp.rs:210] "SynSent handler" = "SynSent handler"
[src/socket.rs:153] "sent" = "sent"
[src/socket.rs:153] &tcp_packet =
            src: 47797
            dst: 40000
            flag: ACK
            payload_len: 0
[src/tcp.rs:229] "status: synsent ->" = "status: synsent ->"
[src/tcp.rs:229] &socket.status = Established
[src/tcp.rs:282] &event = Some(
    TCPEvent {
        sock_id: SockID(
            10.0.0.1,
            10.0.1.1,
            47797,
            40000,
        ),
        kind: ConnectionCompleted,
    },
)
[src/tcp.rs:300] "successfully acked" = "successfully acked"
[src/tcp.rs:300] item.packet.get_seq() = 1709890437
^C[src/socket.rs:153] "sent" = "sent"
[src/socket.rs:153] &tcp_packet =
            src: 47797
            dst: 40000
            flag: ACK FIN
            payload_len: 0
[src/tcp.rs:421] "finwait handler" = "finwait handler"
[src/tcp.rs:346] "ack accept" = "ack accept"
[src/tcp.rs:346] socket.send_param.unacked_seq = 1709890439
[src/tcp.rs:350] "successfully acked" = "successfully acked"
[src/tcp.rs:350] item.packet.get_seq() = 1709890438
[src/tcp.rs:440] "status: finwait1 ->" = "status: finwait1 ->"
[src/tcp.rs:440] &socket.status = FinWait2
[src/tcp.rs:421] "finwait handler" = "finwait handler"
[src/socket.rs:153] "sent" = "sent"
[src/socket.rs:153] &tcp_packet =
            src: 47797
            dst: 40000
            flag: ACK
            payload_len: 0
[src/tcp.rs:282] &event = Some(
    TCPEvent {
        sock_id: SockID(
            10.0.0.1,
            10.0.1.1,
            47797,
            40000,
        ),
        kind: ConnectionClosed,
    },
)
[src/tcp.rs:577] "closed & removed" = "closed & removed"
[src/tcp.rs:577] sock_id = SockID(
    10.0.0.1,
    10.0.1.1,
    47797,
    40000,
)
```