### PR TITLE
Feat: Add fileserver application

### DIFF
--- a/examples/fileclient.rs
+++ b/examples/fileclient.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+use std::{env, fs, net::Ipv4Addr, str};
+use toytcp::tcp::TCP;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let addr: Ipv4Addr = args[1].parse()?;
+    let port: u16 = args[2].parse()?;
+    let filepath: &str = &args[3];
+    file_client(addr, port, filepath)?;
+    Ok(())
+}
+
+fn file_client(remote_addr: Ipv4Addr, remote_port: u16, filepath: &str) -> Result<()> {
+    let tcp = TCP::new();
+    let sock_id = tcp.connect(remote_addr, remote_port)?;
+    let cloned_tcp = tcp.clone();
+    ctrlc::set_handler(move || {
+        cloned_tcp.close(sock_id).unwrap();
+        std::process::exit(0);
+    })?;
+
+    let input = fs::read(filepath)?;
+    tcp.send(sock_id, &input)?;
+    tcp.close(sock_id).unwrap();
+    Ok(())
+}

--- a/examples/fileserver.rs
+++ b/examples/fileserver.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use std::{env, fs, net::Ipv4Addr, str};
+use toytcp::tcp::TCP;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let addr: Ipv4Addr = args[1].parse()?;
+    let port: u16 = args[2].parse()?;
+    let savepath: &str = &args[3];
+    file_server(addr, port, savepath)?;
+    Ok(())
+}
+
+fn file_server(local_addr: Ipv4Addr, local_port: u16, savepath: &str) -> Result<()> {
+    let tcp = TCP::new();
+    let listening_socket = tcp.listen(local_addr, local_port)?;
+    dbg!("listening...");
+    loop {
+        let connected_socket = tcp.accept(listening_socket)?;
+        dbg!("accepted!", connected_socket.1, connected_socket.3);
+        let mut v = Vec::new();
+        let mut buffer = [0u8; 2000];
+        loop {
+            let nbytes = tcp.recv(connected_socket, &mut buffer).unwrap();
+            if nbytes == 0 {
+                dbg!("closing connection...");
+                tcp.close(connected_socket).unwrap();
+                break;
+            }
+            v.extend_from_slice(&buffer[..nbytes]);
+        }
+        fs::write(savepath, &v).unwrap();
+    }
+}


### PR DESCRIPTION
## Overview

「3.10 総まとめ・ファイルアップロード」まで実装

## Test

- server:

```sh
sudo ip netns exec host2 ./target/debug/examples/fileserver 10.0.1.1 40000 ~/Downloads/kafka-paper.pdf
```

- client:

```sh
sudo ip netns exec host1 ./target/debug/examples/fileclient 10.0.1.1 40000 ~/Downloads/kafka.pdf
```

- Check files:

```text
% la ~/Downloads/{kafka.pdf,kafka-paper.pdf}
Permissions Size User Date Modified Name
.rw-r--r--   44M root 25 Feb 13:49  /home/mori/Downloads/kafka-paper.pdf
.rw-r--r--   44M mori 12 Nov  2023  /home/mori/Downloads/kafka.pdf

% md5sum ~/Downloads/kafka.pdf
7f5d31daacb28b481b71feecd0f59b99  /home/mori/Downloads/kafka.pdf

% md5sum ~/Downloads/kafka-paper.pdf
7f5d31daacb28b481b71feecd0f59b99  /home/mori/Downloads/kafka-paper.pdf
```